### PR TITLE
change help icon to info icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) 
 
 ## History
 
+#### Version 1.2.3
+Update help icon to info icon since that is the info section, not a help section. Also updated the scaling effect that
+occurs when the mouse hovers over an icon in the header. I also added some readonly properties in app and tiles that
+reference the icons in use, in that particular component. This may make switching icons around easier but also helps
+ensure that icons don't get forgotten about. Finally, removed some unnecessary comments printed to the dev console.
+
 #### Version 1.2.2
 Added new maps for the background randomizer. Then added logic to randomly select one of these maps
 when the shuffle icon is clicked.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pokedex-landing-page",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -33,5 +33,5 @@
 }
 
 .header-icon.clickable:hover {
-    transform: scale(1.1);
+    transform: scale(1.5);
 }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -10,8 +10,14 @@ import {MaterialModule} from "./materialModule";
     styleUrl: './app.css'
 })
 export class App {
+
+    // icons in use
+    protected readonly icon_info = 'info';
+    protected readonly icon_replay = 'replay';
+    protected readonly icon_shuffle = 'shuffle';
+
     protected readonly title = signal('PokedexLandingPage');
-    protected readonly currentIcon = signal('help');
+    protected readonly currentIcon = signal(this.icon_info);
 
     currentRoute: string;
     previousRoute: string;
@@ -30,7 +36,6 @@ export class App {
     protected readonly backgroundImage = signal(this.backgroundImages[0]);
 
     protected getBackgroundImageUrl(): string {
-        console.debug("Getting background image URL: ", this.backgroundImage());
         return `url('${this.backgroundImage()}')`;
     }
 
@@ -79,15 +84,14 @@ export class App {
 
     private updateIcon(): void {
         if (this.currentRoute.includes('/info')) {
-            this.currentIcon.set('replay');
+            this.currentIcon.set(this.icon_replay);
         } else {
-            this.currentIcon.set('help');
+            this.currentIcon.set(this.icon_info);
         }
     }
 
     toggleBackground(): void {
         const randomIndex = Math.floor(Math.random() * this.backgroundImages.length);
-        console.debug("Random image index: " + randomIndex);
         this.backgroundImage.set(this.backgroundImages[randomIndex]);
     }
 }

--- a/src/tiles/tiles.ts
+++ b/src/tiles/tiles.ts
@@ -33,6 +33,10 @@ import {FormsModule} from "@angular/forms";
 })
 export class Tiles implements OnInit, OnDestroy {
 
+    // icons in use
+    protected readonly icon_sunny = 'sunny';
+    protected readonly icon_bedtime = 'bedtime';
+
     toggle1Checked = false;
     toggle2Checked = false;
     toggle3Checked = false;


### PR DESCRIPTION
Small adjustment to the "info" icon. A help icon was used originally but it's not really help, it is info. So adjusting the icon to adjust intent when users click on it.

<img width="1582" height="1031" alt="Screenshot 2026-01-14 at 7 32 08 PM" src="https://github.com/user-attachments/assets/6aa45d49-9b68-4dc1-b17e-928ca3cd3753" />
<img width="90" height="47" alt="Screenshot 2026-01-14 at 7 33 37 PM" src="https://github.com/user-attachments/assets/aa192859-8173-4118-b158-82f60fe920e2" />
