### PR TITLE
Add landing page deployment workflow

### DIFF
--- a/.github/workflows/landing-page-deploy.yml
+++ b/.github/workflows/landing-page-deploy.yml
@@ -1,0 +1,77 @@
+name: Landing Page Deployment
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build Landing Page
+        run: npm run deployLandingPageForServer
+
+      - name: Upload Landing Page
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          source: "dist/PokedexLandingPage"
+          target: "/tmp/deploy"
+
+      - name: Copy Previous Working Version, Deploy New Version
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY }}
+          script: |
+            # Stop script on a failing command rather than blindly continuing
+            set -e
+
+            # Stop Tomcat 11 Service
+            systemctl stop tomcat11
+
+            # Copy Previous Working Version
+            cd /opt/tomcat11
+            rm -rf MyPokedexBackup/ROOT
+            mkdir -p MyPokedexBackup/ROOT
+            cp -a MyPokedex/ROOT/. MyPokedexBackup/ROOT/
+
+            # Prepare New Version
+            rm -rf MyPokedex/ROOT
+            mv /tmp/deploy/dist/PokedexLandingPage /opt/tomcat11/MyPokedex/ROOT
+
+            cd /opt/tomcat11/MyPokedex/ROOT
+            cp -a browser/. .
+            rm -rf browser
+
+            # Update Ownership
+            chown -R tomcat:tomcat /opt/tomcat11/MyPokedex/ROOT
+            chown -R tomcat:tomcat /opt/tomcat11/MyPokedexBackup/ROOT
+
+            # Update Permissions
+            find /opt/tomcat11/MyPokedex/ROOT -type d -exec chmod 755 {} \;
+            find /opt/tomcat11/MyPokedex/ROOT -type f -exec chmod 644 {} \;
+
+            # Start Tomcat 11 Service
+            systemctl start tomcat11
+
+            # Wait until Tomcat reports active, or fail after 120 seconds
+            timeout 120 bash -c 'until systemctl is-active --quiet tomcat11; do sleep 3; done'
+
+            # Show recent Tomcat logs
+            journalctl -u tomcat11 -n 100 --no-pager


### PR DESCRIPTION
This workflow sets up Node.js, installs dependencies, builds the landing page, uploads it to the server, and manages the deployment process including stopping the Tomcat service, backing up the previous version, and starting the service again.